### PR TITLE
fix: use node actions for v16

### DIFF
--- a/common/.github/workflows/wpstandards.yml
+++ b/common/.github/workflows/wpstandards.yml
@@ -22,12 +22,12 @@ jobs:
       run: |
         sudo composer self-update --1
         sudo chown $USER $HOME/.composer
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nanasess/setup-php@master
       with:
         php-version: '7.4'
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install


### PR DESCRIPTION
When I tried to push to squarecandy-luna github actions failed with message:
```
build (16.x)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```
This seems to fix that issue.